### PR TITLE
add key  to goto declaration, can jump to function declaration in C/C++

### DIFF
--- a/plugin/coc.vim
+++ b/plugin/coc.vim
@@ -103,6 +103,7 @@ inoremap <expr> <cr> pumvisible() ? "\<C-y>" : "\<C-g>u\<CR>"
 
 " Remap keys for gotos
 nmap <silent> gd <Plug>(coc-definition)
+nmap <silent> gh <Plug>(coc-declaration)
 nmap <silent> gy <Plug>(coc-type-definition)
 nmap <silent> gi <Plug>(coc-implementation)
 nmap <silent> gr <Plug>(coc-references-used)


### PR DESCRIPTION
add key `gh` to goto declaration, can jump to function declaration in C/C++. pls review and mr !