### PR TITLE
nvim: Added a shortcut to jump to the next error location(#176)

### DIFF
--- a/nvim/lua/usr/which-key.lua
+++ b/nvim/lua/usr/which-key.lua
@@ -121,6 +121,8 @@ wk.add({
   { "gi",        "<cmd>lua vim.lsp.buf.implementation()<cr>",            desc = "go to implementation" },
   { "gr", "<cmd>lua vim.lsp.buf.references()<cr>",                 desc = "go to reference" },
   { "gw", "<cmd>Telescope diagnostics<cr>",                        desc = "diagnostics" },
+  { "gn", "<cmd>lua vim.diagnostic.goto_next()<cr>",               desc = "go to next error" },
+  { "gN", "<cmd>lua vim.diagnostic.goto_prev()<cr>",               desc = "go to prev error" },
   { "m",  group = "bookmarks" },
   { "ma", "<cmd>Telescope bookmarks<cr>",                          desc = "search bookmarks" },
   { "md", "<cmd>lua require'bookmarks.list'.delete_on_virt()<cr>", desc = "delete bookmark at virt text line" },


### PR DESCRIPTION
Add shortcuts to implement error jumps

- gn : Jump to the next error location
- gN: Jump to the previous error location